### PR TITLE
Fix crash in Hardware Config Wizard when Number of Lasers is > 1.

### DIFF
--- a/LaserDiodeDriver.cpp
+++ b/LaserDiodeDriver.cpp
@@ -151,16 +151,16 @@ int LaserDiodeDriver::Initialize()
       return ret;
    }
 
-   CPropertyAction* pActLaserPower = new CPropertyAction (this, &LaserDiodeDriver::OnLaserPower);
-   CPropertyAction* pActLaserOnOff = new CPropertyAction (this, &LaserDiodeDriver::OnLaserOnOff);
-   CPropertyAction* pActLaserMinPower = new CPropertyAction (this, &LaserDiodeDriver::OnLaserMinPower);
-   CPropertyAction* pActLaserMaxPower = new CPropertyAction (this, &LaserDiodeDriver::OnLaserMaxPower);
-
    std::vector<std::string> digitalValues;
    digitalValues.push_back(OFF);
    digitalValues.push_back(ON);
 
    for (int i = 0; i < numberOfLasers_; ++i) {
+      CPropertyAction* pActLaserPower = new CPropertyAction (this, &LaserDiodeDriver::OnLaserPower);
+      CPropertyAction* pActLaserOnOff = new CPropertyAction (this, &LaserDiodeDriver::OnLaserOnOff);
+      CPropertyAction* pActLaserMinPower = new CPropertyAction (this, &LaserDiodeDriver::OnLaserMinPower);
+      CPropertyAction* pActLaserMaxPower = new CPropertyAction (this, &LaserDiodeDriver::OnLaserMaxPower);
+
       char p_name[64];
 
       // Laser power


### PR DESCRIPTION
This fixes #1.

The crash was caused by the same Action Handlers being assigned to multiple properties. MM would crash on deleting the same Handler twice when deleting the device.